### PR TITLE
feat: add acceptance report comment workflow

### DIFF
--- a/.github/workflows/acceptance-comment.yml
+++ b/.github/workflows/acceptance-comment.yml
@@ -1,0 +1,51 @@
+name: Acceptance Report (comment)
+on:
+  workflow_run:
+    workflows: ["Smoke (Acceptance)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR info
+        id: pr
+        uses: actions-ecosystem/action-get-merged-pull-request@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+        continue-on-error: true
+
+      - name: Derive PR number fallback
+        id: derive
+        run: |
+          echo "pr_number=${{ steps.pr.outputs.number || '' }}" >> $GITHUB_OUTPUT
+
+      - name: Build report
+        id: report
+        run: |
+          STATUS="${{ github.event.workflow_run.conclusion }}"
+          DURATION="$(( (github.event.workflow_run.run_duration_ms || 0) / 1000 ))s"
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+          echo "body=**Acceptance Report** — Smoke: **${STATUS}** in ${DURATION}%0A\
+          • UI: http://99.76.234.25:5000/health%0A\
+          • API: http://99.76.234.25:5055/api/health%0A\
+          • Doctor: http://99.76.234.25:5056/lab/doctor/packs%0A\
+          • Artifacts: ${ARTIFACT_URL}%0A" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: steps.derive.outputs.pr_number != ''
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: ${{ steps.report.outputs.body }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          pr-number: ${{ steps.derive.outputs.pr_number }}


### PR DESCRIPTION
## Summary
- Adds workflow that posts comment on PRs after Smoke (Acceptance) completes
- Shows pass/fail status, duration, and links to health endpoints
- Includes link to workflow artifacts

## Test Plan
- This PR will test itself when Smoke completes
- Should see an automated comment with the acceptance report