### PR TITLE
chore: update GitHub org references to donny-ai-team

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -56,7 +56,7 @@ Donny-V4/
 - Branches:  
   - `main` → Production  
   - `lab` → Testing  
-- Both branches pushed to GitHub: https://github.com/harrynanre/Donny-V4
+- Both branches pushed to GitHub: https://github.com/donny-ai-team/Donny-V4
 
 ---
 

--- a/setup_branch_protection.sh
+++ b/setup_branch_protection.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Setup branch protection for lab branch
+
+OWNER="donny-ai-team"
+REPO="Donny-V4"
+
+echo "Setting up branch protection for lab branch..."
+
+gh api \
+  -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/$OWNER/$REPO/branches/lab/protection" \
+  -f required_pull_request_reviews='{"required_approving_review_count":1}' \
+  -f enforce_admins=false \
+  -f required_status_checks='{"strict":true,"checks":[{"context":"Smoke / smoke"}]}' \
+  -f restrictions=null
+
+echo "Branch protection configured!"
+echo "Rules applied:"
+echo "- Require 1 approval"
+echo "- Require 'Smoke / smoke' status check to pass"
+echo "- Status checks must be up-to-date (strict mode)"


### PR DESCRIPTION
## Changes
- Updated MILESTONES.md: Changed GitHub URL from harrynanre to donny-ai-team
- Updated setup_branch_protection.sh: Changed OWNER from harrynanre to donny-ai-team

## Why
The repository organization has been renamed from onny-ai-team to donny-ai-team. This PR updates all references to use the new organization name.