### PR TITLE
fix: move auto-retry workflow to correct location

### DIFF
--- a/.github/workflows/auto-retry-smoke.yml
+++ b/.github/workflows/auto-retry-smoke.yml
@@ -1,0 +1,71 @@
+name: Auto-retry Smoke (one-time)
+
+on:
+  workflow_run:
+    workflows: ["Smoke (Acceptance)"]  # must match the name shown in Actions left sidebar
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  maybe-rerun:
+    # Only if the first attempt failed (Attempt 1)
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find related PRs
+        id: find
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            const prs = await github.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
+              owner, repo, commit_sha: sha,
+              headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+            });
+            core.setOutput('prs', JSON.stringify(prs.data.map(p => p.number)));
+
+      - name: Skip if PR labeled no-retry
+        id: gate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const numbers = JSON.parse(core.getInput('numbers'));
+            if (!numbers.length) { core.setOutput('go', 'true'); return; }
+            const { owner, repo } = context.repo;
+            const pr = numbers[0];
+            const { data } = await github.rest.issues.get({ owner, repo, issue_number: pr });
+            const labels = (data.labels || []).map(l => l.name);
+            core.setOutput('go', labels.includes('no-retry') ? 'false' : 'true');
+        env:
+          numbers: ${{ steps.find.outputs.prs }}
+
+      - name: Re-run Smoke (1/1)
+        if: ${{ steps.gate.outputs.go == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run_id = context.payload.workflow_run.id;
+            await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun', { owner, repo, run_id });
+
+      - name: Comment on PR(s)
+        if: ${{ steps.gate.outputs.go == 'true' && steps.find.outputs.prs != '[]' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const nums = JSON.parse(core.getInput('numbers'));
+            for (const n of nums) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: n,
+                body: "🔁 Auto-retry: Smoke failed once, retrying automatically (1/1)."
+              });
+            }
+        env:
+          numbers: ${{ steps.find.outputs.prs }}


### PR DESCRIPTION
### Quick checks
- [ ] All health endpoints GREEN (UI `/health`, API `/api/health`, Doctor `/lab/api/browser/health`)
- [ ] Smoke test passes locally (`TARGET_HOST=99.76.234.25 node ops/tests/acceptance/smoke.mjs`)
- [ ] No secrets/keys in the diff
- [ ] Doctor Packs show overall **PASS** at `/lab/doctor/packs`
- [ ] Artifacts accessible (e.g., `/files/artifacts/...`)
- [ ] Includes link to acceptance pack (CI artifact) if relevant

> Notes:

---
**Reviews**
- [ ] At least 1 approval (auto-requested by CODEOWNERS)
