### PR TITLE
auto-retry-smoke.yml

### DIFF
--- a/.github/workflows/auto-retry-smoke.yml
+++ b/.github/workflows/auto-retry-smoke.yml
@@ -43,7 +43,7 @@ jobs:
             const labels = (data.labels || []).map(l => l.name);
             core.setOutput('go', labels.includes('no-retry') ? 'false' : 'true');
         env:
-          numbers: ${{ steps.find.outputs.prs }}
+          numbers: ${{ steps.find.outputs.numbers }}
 
       - name: Re-run Smoke (1/1)
         if: ${{ steps.gate.outputs.go == 'true' }}


### PR DESCRIPTION
### Quick checks
- [ ] All health endpoints GREEN (UI `/health`, API `/api/health`, Doctor `/lab/api/browser/health`)
- [ ] Smoke test passes locally (`TARGET_HOST=99.76.234.25 node ops/tests/acceptance/smoke.mjs`)
- [ ] No secrets/keys in the diff
- [ ] Doctor Packs show overall **PASS** at `/lab/doctor/packs`
- [ ] Artifacts accessible (e.g., `/files/artifacts/...`)
- [ ] Includes link to acceptance pack (CI artifact) if relevant

> Notes:

---
**Reviews**
- [ ] At least 1 approval (auto-requested by CODEOWNERS)
