### PR TITLE
feat: add slow badge and threshold display to Doctor packs UI

### DIFF
--- a/apps/doctor/src/packsRoute.ts
+++ b/apps/doctor/src/packsRoute.ts
@@ -3,12 +3,25 @@ export function packsHtml(data: any) {
     ? '<span style="padding:6px 10px;border-radius:999px;background:#ecfdf5;border:1px solid #bbf7d0;color:#16a34a;font-size:12px">PASS</span>'
     : '<span style="padding:6px 10px;border-radius:999px;background:#fef2f2;border:1px solid #fecaca;color:#ef4444;font-size:12px">FAIL</span>';
 
-  const rows = (data.results || []).map((r:any)=>`
+  const rows = (data.results || []).map((r:any)=>{
+    const slowBadge = r.slow 
+      ? '<span style="padding:4px 8px;border-radius:6px;background:#fffbeb;border:1px solid #fde68a;color:#f59e0b;font-size:11px;margin-left:8px">⚠️ slow</span>'
+      : '';
+    const threshold = typeof r.thresholdMs === 'number' 
+      ? `<span class="muted" style="margin-left:8px;font-size:11px">≤ ${r.thresholdMs}ms</span>`
+      : '';
+    
+    return `
     <div class="row">
       <span>${r.name.toUpperCase()} &nbsp;<span class="muted">(${r.url})</span></span>
-      <span>${badge(!!r.ok)} <span class="muted" style="margin-left:6px">${r.ms ?? 0} ms</span></span>
+      <span>
+        ${badge(!!r.ok)} 
+        <span class="muted" style="margin-left:6px">${r.ms ?? 0}ms</span>
+        ${threshold}
+        ${slowBadge}
+      </span>
     </div>
-  `).join("");
+  `}).join("");
 
   return `
   <div class="card">


### PR DESCRIPTION
## Summary
- Shows latency threshold (≤ XXXms) for each check
- Displays ⚠️ slow badge when check exceeds threshold
- Visual feedback for performance monitoring

## Changes
- Updated `packsRoute.ts` to render threshold values and slow badges
- Slow checks get a yellow warning badge
- Each check shows its configured threshold

## Testing
Visit http://99.76.234.25:5056/lab/doctor/packs to see:
- Each check shows its latency and threshold
- Slow badges appear when latency > threshold