### PR TITLE
feat: add incident auto-issue on 3 consecutive Smoke fails

### DIFF
--- a/.github/workflows/incident-on-3-fails.yml
+++ b/.github/workflows/incident-on-3-fails.yml
@@ -1,0 +1,153 @@
+name: Incident on 3 Smoke Fails
+
+on:
+  workflow_run:
+    workflows: ["Smoke (Acceptance)"]
+    types: [completed]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Short-circuit if no associated PR
+        id: find
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            const prs = await github.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
+              owner, repo, commit_sha: sha,
+              headers: { 'X-GitHub-Api-Version': '2022-11-28' }
+            });
+            const numbers = prs.data.map(p => p.number);
+            core.setOutput('pr_json', JSON.stringify(numbers));
+            core.setOutput('pr', numbers[0] || '');
+            core.setOutput('sha', sha);
+
+      - name: Stop if no PR
+        if: ${{ steps.find.outputs.pr == '' }}
+        run: echo "No PR for this SHA; nothing to track."
+
+      - name: Checkout gate-state branch (create if missing)
+        if: ${{ steps.find.outputs.pr != '' }}
+        run: |
+          set -e
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # Try to fetch existing gate-state, else start from empty tree
+          if git ls-remote --exit-code origin gate-state >/dev/null 2>&1; then
+            git fetch origin gate-state --depth=1
+            git checkout -B gate-state origin/gate-state
+          else
+            git checkout --orphan gate-state
+            rm -rf *
+            mkdir -p .ops/incidents
+            git add -A
+            git -c user.name='gate-bot' -c user.email='gate-bot@users.noreply.github.com' commit -m "chore: init gate-state"
+            git push -u origin gate-state
+          fi
+
+      - name: Update fail counter for this PR
+        id: count
+        if: ${{ steps.find.outputs.pr != '' }}
+        shell: bash
+        env:
+          PR_NUM: ${{ steps.find.outputs.pr }}
+          SHA: ${{ steps.find.outputs.sha }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_HTML: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -e
+          mkdir -p .ops/incidents
+          FILE=".ops/incidents/pr-${PR_NUM}.json"
+          if [ -f "$FILE" ]; then
+            COUNT=$(jq -r '.count // 0' "$FILE")
+            RUNS=$(jq -c '.runs // []' "$FILE")
+          else
+            COUNT=0
+            RUNS="[]"
+          fi
+
+          if [ "$CONCLUSION" = "failure" ]; then
+            COUNT=$((COUNT+1))
+          else
+            COUNT=0
+          fi
+
+          # Keep last 3 run URLs
+          echo "$RUNS" | jq -r '.' > /tmp/runs.json
+          jq --arg url "$RUN_HTML" '. + [$url] | (length>3 ? .[-3:] : .)' /tmp/runs.json > /tmp/runs2.json
+
+          jq -n --arg pr "$PR_NUM" --arg sha "$SHA" --argjson count "$COUNT" \
+                --slurpfile runs /tmp/runs2.json \
+                '{pr: ($pr|tonumber), sha: $sha, count: $count, runs: $runs[0], updatedAt: (now|todate)}' > "$FILE"
+
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+      - name: Commit updated counter
+        if: ${{ steps.find.outputs.pr != '' }}
+        run: |
+          set -e
+          git add .ops/incidents/
+          if git diff --staged --quiet; then
+            echo "No counter changes"
+          else
+            git -c user.name='gate-bot' -c user.email='gate-bot@users.noreply.github.com' \
+              commit -m "gate(incident): update fail counter for PR #${{ steps.find.outputs.pr }} to ${{ steps.count.outputs.count }}"
+            git push origin HEAD:gate-state
+          fi
+
+      - name: Open/Update Incident Issue at 3 fails
+        if: ${{ steps.count.outputs.count >= 3 && steps.find.outputs.pr != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNum = Number(core.getInput('pr', {required:false})) || Number(process.env.PR_NUM || 0);
+            const sha = process.env.SHA;
+            const runUrl = context.payload.workflow_run.html_url;
+
+            // Get PR info for author mention
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNum });
+            const author = pr.data.user.login;
+
+            // Build body
+            const body = [
+              `⚠️ **Lab Gate Incident** — 3 consecutive Smoke failures`,
+              ``,
+              `**PR:** #${prNum} (${author})`,
+              `**SHA:** \`${sha}\``,
+              `**Latest run:** ${runUrl}`,
+              `**Doctor Pack:** http://99.76.234.25:5056/lab/api/packs/latest`,
+              ``,
+              `**Next steps**`,
+              `- [ ] Investigate failing endpoint/logs`,
+              `- [ ] Fix and push`,
+              `- [ ] Confirm gate is green`,
+              ``,
+              `cc @${author}`
+            ].join('\n');
+
+            // Create issue
+            const issue = await github.rest.issues.create({
+              owner, repo,
+              title: `Lab Gate Incident: PR #${prNum} (${sha.slice(0,7)})`,
+              body,
+              labels: ['incident','smoke-failure','automated']
+            });
+
+            // Comment on PR for visibility
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: prNum,
+              body: `🚨 Incident opened: #${issue.data.number} — 3 consecutive Smoke failures.`
+            });
+        env:
+          PR_NUM: ${{ steps.find.outputs.pr }}
+          SHA: ${{ steps.find.outputs.sha }}


### PR DESCRIPTION
## Quick checks
- [ ] All health endpoints GREEN (UI /health, API /api/health, Doctor /lab/api/browser/health)
- [ ] Smoke test passes locally (`IMAGE=99.76.234.25 node ops/tests/acceptance/smoke.mjs`)
- [ ] No secrets/keys in the diff
- [ ] Doctor Packs show overall PASS ✅ (lab/doctor/packs)
- [ ] Artifacts accessible (e.g., /files/artifacts/*)
- [ ] Includes link to acceptance pack (CI artifact) if relevant

## Notes
(What changed + any risks)

## Labels
Add one: `ready-to-merge` (if green) or `needs-investigation` (if red)
