### PR TITLE
fix: trigger incident when fail count >= 3

### DIFF
--- a/.github/workflows/incident-on-3-fails.yml
+++ b/.github/workflows/incident-on-3-fails.yml
@@ -124,8 +124,8 @@ jobs:
           git push origin gate-state || true
           echo "counter committed (or no changes)"
 
-      - name: Open Incident issue at exactly 3 fails
-        if: ${{ steps.count.outputs.count == 3 && steps.find.outputs.pr != '' }}
+      - name: Open Incident issue when fail count ≥ 3
+        if: ${{ steps.count.outputs.count >= 3 && steps.find.outputs.pr != '' }}
         continue-on-error: true
         uses: actions/github-script@v7
         env:
@@ -144,7 +144,7 @@ jobs:
               const author = pr.data.user.login;
 
               const body = [
-                `⚠️ **Lab Gate Incident** — 3 consecutive Smoke failures`,
+                `⚠️ **Lab Gate Incident** — 3+ consecutive Smoke failures`,
                 ``,
                 `**PR:** #${prNum} (@${author})`,
                 `**SHA:** \`${sha}\``,
@@ -166,7 +166,7 @@ jobs:
 
               await github.rest.issues.createComment({
                 owner, repo, issue_number: prNum,
-                body: `🚨 Incident opened: #${issue.data.number} — 3 consecutive Smoke failures.`
+                body: `🚨 Incident opened: #${issue.data.number} — 3+ consecutive Smoke failures.`
               });
               core.info(`Incident #${issue.data.number} opened.`);
             } catch (e) {


### PR DESCRIPTION
## Quick checks
- [ ] All health endpoints GREEN (UI /health, API /api/health, Doctor /lab/api/browser/health)
- [ ] Smoke test passes locally (`IMAGE=99.76.234.25 node ops/tests/acceptance/smoke.mjs`)
- [ ] No secrets/keys in the diff
- [ ] Doctor Packs show overall PASS ✅ (lab/doctor/packs)
- [ ] Artifacts accessible (e.g., /files/artifacts/*)
- [ ] Includes link to acceptance pack (CI artifact) if relevant

## Notes
(What changed + any risks)

## Labels
Add one: `ready-to-merge` (if green) or `needs-investigation` (if red)
