### PR TITLE
revert: restore TARGET_HOST to 99.76.234.25

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      TARGET_HOST: 127.0.0.1
+      TARGET_HOST: 99.76.234.25
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}


### PR DESCRIPTION
## Quick checks
- [ ] All health endpoints GREEN (UI /health, API /api/health, Doctor /lab/api/browser/health)
- [ ] Smoke test passes locally (`IMAGE=99.76.234.25 node ops/tests/acceptance/smoke.mjs`)
- [ ] No secrets/keys in the diff
- [ ] Doctor Packs show overall PASS ✅ (lab/doctor/packs)
- [ ] Artifacts accessible (e.g., /files/artifacts/*)
- [ ] Includes link to acceptance pack (CI artifact) if relevant

## Notes
(What changed + any risks)

## Labels
Add one: `ready-to-merge` (if green) or `needs-investigation` (if red)
